### PR TITLE
Handled status updates when events switch back and forth.

### DIFF
--- a/app/com/logistimo/db/DeviceStatus.java
+++ b/app/com/logistimo/db/DeviceStatus.java
@@ -150,9 +150,9 @@ public class DeviceStatus {
     JPA.em().remove(this);
   }
 
-  public void copyStatus(DeviceStatus deviceStatus) {
+  public void copyStatus(DeviceStatus deviceStatus, Integer latestStatusUpdateTime) {
     this.status = deviceStatus.status;
-    this.statusUpdatedTime = deviceStatus.statusUpdatedTime;
+    this.statusUpdatedTime = latestStatusUpdateTime;
     this.temperature = deviceStatus.temperature;
     this.temperatureAbnormalStatus = deviceStatus.temperatureAbnormalStatus;
     this.temperatureUpdatedTime = deviceStatus.temperatureUpdatedTime;


### PR DESCRIPTION
 Identify the latest status update time from the list of device status and use that to set at the transition time to this event.